### PR TITLE
ci(actions): do not run upgrade on fork

### DIFF
--- a/.github/workflows/bump-swc_core.yml
+++ b/.github/workflows/bump-swc_core.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   upgrade-swc-core:
+    if: >-
+      ${{ github.repository_owner == 'swc-project' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Limiting actions to not run in the forks as it is redundant.